### PR TITLE
Update github workflow to include `latest` branch for releases

### DIFF
--- a/.github/workflows/feature-branch-test.yml
+++ b/.github/workflows/feature-branch-test.yml
@@ -2,7 +2,7 @@ name: Feature branch test
 
 on:
   pull_request:
-    branches: [ "master", "production" ]
+    branches: [ "master", "production", "latest" ]
 
 jobs:
   test:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,11 +1,11 @@
 # 1. Build the test image using current commit hash as tag.
 # 2. Pull test image, run tests, clean up test image.
-# 3. Build production ready image for staging or production.
+# 3. Build stable image.
 name: release
 
 on:
   push:
-    branches: ["production"]
+    branches: ["production", "latest"]
 
 jobs:
   test:


### PR DESCRIPTION
Add the `latest` branch on the pull request workflow and release workflow. This will replace the `production` branch later.