### PR TITLE
Fix broken ciphers query due to missing arguments.

### DIFF
--- a/mp/apps/cipher/graphql/types.py
+++ b/mp/apps/cipher/graphql/types.py
@@ -43,7 +43,7 @@ class Cipher(relay.Node):
 @strawberry.type
 class CipherConnection(relay.ListConnection[Cipher]):
     @classmethod
-    def resolve_node(cls, node: CipherModel) -> Cipher:  # type: ignore[override]
+    def resolve_node(cls, node: CipherModel, **_kwargs) -> Cipher:  # type: ignore[override]
         return Cipher.from_model(node)
 
 

--- a/mp/apps/cipher/models.py
+++ b/mp/apps/cipher/models.py
@@ -68,7 +68,7 @@ class Cipher(Model):
         )
 
     def __str__(self) -> str:
-        return f"{self.__class__.__name__}:{self.type} - {self.id}"
+        return f"{self.__class__.__name__}:{self.type} - {self.pk}"
 
 
 class CipherModelMixin(Model):
@@ -86,7 +86,7 @@ class CipherModelMixin(Model):
         abstract = True
 
     def __str__(self) -> str:
-        return f"{self.__class__.__name__}:{self.id}"  # type: ignore[attr-defined]
+        return f"{self.__class__.__name__}:{self.pk}"
 
     @property
     def cipher(self) -> Cipher | None:


### PR DESCRIPTION
#### Ticket
<!-- Replace XXXX (e.g. #1) with the corresponding Github issue ticket number. You may also use N/A for trivial PR.-->

#89 

#### Branch description

Due to some refactoring on #6, some of the unused arguments and variables were removed. This MR will add a default `**_kwargs` argument to ensure that the `CipherConnection.resolve_node` won't miss an argument and fix the error.

#### Checklist
- [x] This PR targets the `main` branch.
- [x] The commit message should follow [conventional commit standard](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have added or updated relevant tests.
- [ ] I have attached screenshots for any UI changes.
